### PR TITLE
fix(server, client): Selector와 ThreadPool 간 동작 수정

### DIFF
--- a/client/src/main/java/Client.java
+++ b/client/src/main/java/Client.java
@@ -25,19 +25,10 @@ public class Client {
             if (socketChannel.isOpen()) { stopClient(); }
             return;
         }
-
-        Runnable readRunnable = () -> receive();
-        executorService.submit(readRunnable);
-
         /*
         * client가 끊기지 않도록 계속 구동하는 부분
         * while(true) {  }
         * */
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
     }
 
     void stopClient() {
@@ -51,7 +42,10 @@ public class Client {
     }
 
     void receive() {
-        System.out.println("receive");
+        Runnable readRunnable = () -> {
+            System.out.println("receive");
+        };
+        executorService.submit(readRunnable);
     }
 
     void send(ByteBuffer byteBufferData) {
@@ -75,6 +69,6 @@ public class Client {
     public static void main(String[] args) {
         Client client = new Client();
         client.startClient();
-//        client.send(Charset.forName("UTF-8").encode("hello"));
+        client.send(Charset.forName("UTF-8").encode("hello"));
     }
 }


### PR DESCRIPTION
server
 - Selector에 등록된 SocketChannel의 interestOps가 OP_READ인 상태에서 ThreadPool로 read 동작을 던지고 Selector가 다시 돌아 실제로 read 동작이 진행되지 않았음에도 지속적으로 돌아 빈 값을 읽어오고 있던 동작에 대한 수정

client
 - connect() method 내에서 ThreadPool에 read 동작 던지던 부분 수정